### PR TITLE
Update for breaking change in python-client 0.0.37

### DIFF
--- a/rplugin/python3/nvim_jupyter/__init__.py
+++ b/rplugin/python3/nvim_jupyter/__init__.py
@@ -54,7 +54,7 @@ class NVimJupyter:
         nvim: object
             The `neovim` communication channel.
         """
-        self.nvim = nvim.with_hook(nv.DecodeHook())
+        self.nvim = nvim
         self.argp = u.set_argparser(c.args_to_set)
         self.new_kernel_started = None
         self.buffer = None
@@ -69,17 +69,11 @@ class NVimJupyter:
         ----------
         args: list of str
             Arguments passed from `neovim`.
-
-        Notes
-        -----
-        There's a problem: `neovim` passes a `list` of `bytes` instead of
-        `str`. Need to manually decode them.
         """
         # allow only one connection
         if self.kc is not None:
             return
 
-        args = u.decode_args(self.nvim, args)
         args = self.argp.parse_args(['JKernel'] + args)
         try:
             l.debug('KERNEL START')

--- a/rplugin/python3/nvim_jupyter/utils.py
+++ b/rplugin/python3/nvim_jupyter/utils.py
@@ -47,12 +47,3 @@ def format_msg(msg):
     l.debug('FORMATTED {}'.format(formatted_msg))
     return formatted_msg
 
-
-def decode_args(nvim, args):
-    """Helper function to decode from `bytes` to `str`
-
-    `neovim` has some issues with encoding in Python3.
-    """
-    encoding = nvim.eval('&encoding')
-    return [arg.decode(encoding) if isinstance(arg, bytes) else arg
-            for arg in args]


### PR DESCRIPTION
Remove bytes to str conversion, as this is done automatically now.
Ref neovim/python-client#129